### PR TITLE
fix: foundry-grid DOF sizing (cube root + design-restricted np)

### DIFF
--- a/src/Types/FoundryGrid.jl
+++ b/src/Types/FoundryGrid.jl
@@ -42,8 +42,10 @@ Base.show(io::IO, g::FoundryGrid) = print(io, "FoundryGrid($(length(g.x))×$(len
 """
     getgrid(labels, Ω, np, nodes; sizes=nothing) -> FoundryGrid
 
-Build a FoundryGrid from mesh topology. The grid covers the x-y extent of the
-design region with approximately √np points per side.
+Build a FoundryGrid whose 2D pixel density matches the FEM resolution of the
+design region. For a 3D design (Δz > 0), `nx·ny·nz ≈ np` ⇒ roughly one pixel
+per mesh cell on the design midplane. The caller is expected to pass a
+design-restricted DOF count as `np`; see the call site in `build_simulation`.
 """
 function getgrid(labels, Ω, np, nodes; sizes=nothing)
     if isnothing(sizes)
@@ -102,9 +104,11 @@ function getgrid(labels, Ω, np, nodes; sizes=nothing)
 
     Δx, Δy, Δz = (highx - lowx), (highy - lowy), (highz - lowz)
 
-    # Legacy density rule: include design thickness when available.
+    # Match pixel density to design-region FEM resolution. For a cubic design
+    # with n^3 mesh DOFs we want nx ≈ n per axis, i.e. ρ = n/L = np^(1/3)/V^(1/3).
+    # The 2D branch covers true 2D geometries (Δz = 0) where nx·ny ≈ np.
     ρ = if Δz > 0.0
-        √(np) / (Δx * Δy * Δz)^(1 / 3)
+        np^(1 / 3) / (Δx * Δy * Δz)^(1 / 3)
     else
         √(np) / (Δx * Δy)^(1 / 2)
     end

--- a/src/Types/Simulation.jl
+++ b/src/Types/Simulation.jl
@@ -165,7 +165,11 @@ function build_simulation(meshfile::String;
         end
     end
     np_mesh = num_free_dofs(sim.P)
-    sim.grid = getgrid(sim.labels, sim.Ω, np_mesh, nodes; sizes)
+    # FoundryGrid sizing uses design-restricted cell count so nx/ny track
+    # FEM resolution inside the design region, independent of air/substrate/PML
+    # mesh refinement. `sim.P` is Lagrange P0, so cells = DOFs on that subset.
+    np_design = count(cellmask_d)
+    sim.grid = getgrid(sim.labels, sim.Ω, np_design, nodes; sizes)
 
     # DOF count based on mode
     if foundry_mode

--- a/test/objective_baselines_tests.jl
+++ b/test/objective_baselines_tests.jl
@@ -33,15 +33,18 @@ const CASES = [
 const OBJECTIVE_BASELINES = Dict(
     "3D Anisotropic + Multi Output" => (len=813, norm=14.345340287591288, obj=116460.59121184202),
     "3D Inelastic Scattering" => (len=813, norm=14.345340287591288, obj=106857.88184860666),
-    "2D Foundry Anisotropic + Multi Output" => (len=10000, norm=50.37032830942858, obj=995260.7610887402),
-    "2D Foundry Anisotropic" => (len=10000, norm=50.37032830942858, obj=986770.7457187152),
+    # Foundry baselines updated after the getgrid sizing fix (cube root +
+    # design-restricted np): nx×ny dropped from 100×100 to 17×17, which
+    # shifts every downstream value (p length, norm, objective).
+    "2D Foundry Anisotropic + Multi Output" => (len=289, norm=8.588540846480063, obj=1.0190166191632946e6),
+    "2D Foundry Anisotropic" => (len=289, norm=8.588540846480063, obj=1.0102446065974964e6),
     "3D Surface Objective" => (len=813, norm=14.345340287591288, obj=1447.3803882181296),
     "3D With Damage Model" => (len=813, norm=14.345340287591288, obj=106625.11391929301),
     "3D Elastic Baseline" => (len=813, norm=14.345340287591288, obj=106625.11391929301),
     "3D Anisotropic (Elastic)" => (len=813, norm=14.345340287591288, obj=114082.55721479755),
-    "2D Foundry Inelastic" => (len=10000, norm=50.37032830942858, obj=896830.5675490539),
+    "2D Foundry Inelastic" => (len=289, norm=8.588540846480063, obj=915937.6261181335),
     "3D Complex Configuration" => (len=813, norm=14.345340287591288, obj=108785.70661678203),
-    "2D Foundry Mode" => (len=10000, norm=50.37032830942858, obj=922266.9934199577),
+    "2D Foundry Mode" => (len=289, norm=8.588540846480063, obj=944212.861811626),
 )
 
 function outputs_for_case(case::CaseSpec)


### PR DESCRIPTION
## Summary

Fixes `getgrid` density formula, which was silently oversampling the 2D foundry pixel grid by ~30–150× relative to the in-plane FEM resolution of the design region. Two compounding bugs:

1. **Wrong exponent.** 3D branch used `sqrt(np) / V^(1/3)`, giving `nx ~ n^(3/2)` for an `n^3`-DOF cube. Correct is `np^(1/3) / V^(1/3)`.
2. **Scope mismatch.** `np = num_free_dofs(sim.P)` counts DOFs over the whole model (substrate + design + fluid + PML), while the bbox used inside `getgrid` is the design region. Mixing the two scopes has no clean physical meaning.

Fix (three touches):
- `src/Types/FoundryGrid.jl` — cube-root exponent in the 3D branch, updated docstring.
- `src/Types/Simulation.jl` — feed `count(cellmask_d)` (design-restricted P0 cells) to `getgrid`.
- `test/objective_baselines_tests.jl` — refresh four foundry baselines (len/norm/obj) under the new grid sizing.

## Measured oversample (nx·ny ÷ in-plane design-face cells)

| l2 | current | cube-root only | **both fixes (this PR)** |
|---|---:|---:|---:|
| 30 nm | 75×75 (29×) | 19×19 (1.9×) | **14×14 (1.0×)** |
| 10 nm | 332×332 (72×) | 49×49 (1.6×) | **40×40 (1.0×)** |
|  5 nm | 927×927 (143×) | 97×97 (1.6×) | **78×78 (1.0×)** |

The 2D branch (Δz = 0, real 2D geometries) is unchanged.

## What does NOT change

- Main physics objective: Maxwell PDE is solved on the FE mesh; grid size never enters.
- Filter (`Filtering2D.filter_grid`): uses physical R via `resolution = (nx-1)/Lx`. Convergent under any grid sizing.
- 3D SSP (`project_ssp`): uses `control.R_ssp` in nm, not tied to the foundry grid.
- Grid→mesh bilinear interpolation and its adjoint scatter: index-only; unchanged.

## What does change quantitatively

The constraint-mode SSP in `smoothed_projection` uses `R_smoothing = 0.55 · dx` where `dx = 1/resolution`. Under the old oversampled grid that was sub-angstrom (effectively a no-op). Under the fix it runs at mesh scale — which is what the Christiansen SSP was originally designed to do. Downstream effect: constraint active-set timing during β-continuation will shift. No tolerances loosened.

## Test plan

- [x] `Pkg.test()` passes (77/77)
- [x] All 3D-mode objective baselines unchanged
- [x] 4 foundry-mode objective baselines regenerated from the same seeded `gen_p0` + same geometry
- [x] Gradient FD checks still pass at existing tolerances (rel_err < 1e-3 / < 1e-2)
- [x] Constraint FD checks still pass at existing tolerances
- [x] Constrained-optimization schedule (5-iter smoke) passes for both 2D and 3D
