### PR TITLE
fix(ssp): flat-field branch of DSP_dpf missing the test-function factor p (4x gradient at uniform init)

### DIFF
--- a/src/TopologyOpt/Projection3D.jl
+++ b/src/TopologyOpt/Projection3D.jl
@@ -63,7 +63,7 @@ function DSP_dpf(p::Real, ρ̃::Real, ∇ρ̃; R::Float64, β::Float64, η::Floa
 
     norm∇ρ̃ = sqrt(∇ρ̃ ⋅ ∇ρ̃)
     if norm∇ρ̃ < 1e-8
-        return ∂projection_∂pf(ρ̃, β, η)
+        return ∂projection_∂pf(ρ̃, β, η) * p
     end
 
     d = ((η - ρ̃) / norm∇ρ̃) / R

--- a/test/projection_derivative_tests.jl
+++ b/test/projection_derivative_tests.jl
@@ -1,0 +1,53 @@
+"""
+Projection derivative tests — the SSP flat-field branch.
+
+Regression test for the ×4 flat-field gradient bug: the degenerate branch of
+`DSP_dpf` (‖∇ρ̃‖ < 1e-8) returned `∂projection_∂pf(ρ̃, β, η)` WITHOUT the `* p`
+test-function factor that the non-degenerate branch carries. On P1 tets each
+nodal entry then received the full cell integral instead of its 1/4 share —
+a gradient exactly 4× too large wherever the filtered field is flat (in
+particular at uniform initialization, where it fires on every design cell and
+locks CCSA into permanent step rejection: actual/predicted decrease = 1/4 < 1/2).
+
+Root-caused 2026-07-20 (continue-figures quest); frozen-run forensics and the
+escape-race mechanism 2026-08-07 (engaging-deo quest).
+
+Run with: julia --project test/projection_derivative_tests.jl
+"""
+
+using DistributedEmitterOpt
+using LinearAlgebra
+using Test
+
+const DEO = DistributedEmitterOpt
+
+@testset "DSP_dpf flat-field branch" begin
+    R, β, η = 1.5, 8.0, 0.5
+    ρ̃ = 0.5
+
+    @testset "carries the test-function factor p" begin
+        # In the flat-field limit the SSP derivative must reduce to the plain
+        # projection derivative TIMES the test function p — the same factor the
+        # non-degenerate branch applies to both of its projected terms.
+        for p in (0.25, 0.5, 1.0)
+            got = DEO.DSP_dpf(p, ρ̃, [0.0, 0.0, 0.0]; R, β, η)
+            want = DEO.∂projection_∂pf(ρ̃, β, η) * p
+            @test got ≈ want rtol = 1e-14
+        end
+        # Linearity in p (the bug made this constant in p):
+        d1 = DEO.DSP_dpf(1.0, ρ̃, [0.0, 0.0, 0.0]; R, β, η)
+        d4 = DEO.DSP_dpf(0.25, ρ̃, [0.0, 0.0, 0.0]; R, β, η)
+        @test d1 ≈ 4 * d4 rtol = 1e-14
+    end
+
+    @testset "continuity across the degeneracy threshold" begin
+        # The two branches must agree (to the smoothing scale) as ‖∇ρ̃‖ crosses
+        # 1e-8. With the missing *p the jump is a factor 1/p — for p=0.25 a 4×
+        # discontinuity this test catches immediately.
+        p = 0.25
+        n̂ = [1.0, 0.0, 0.0]
+        below = DEO.DSP_dpf(p, ρ̃, 0.99e-8 * n̂; R, β, η)
+        above = DEO.DSP_dpf(p, ρ̃, 1.01e-8 * n̂; R, β, η)
+        @test below ≈ above rtol = 1e-6
+    end
+end


### PR DESCRIPTION
## The bug

The degenerate branch of `DSP_dpf` in `src/TopologyOpt/Projection3D.jl` (taken when `‖∇ρ̃‖ < 1e-8`) returns `∂projection_∂pf(ρ̃, β, η)` **without the test-function factor `p`** that the non-degenerate branch carries on both of its projected terms (`dx_±eff_projected_dpf = ∂projection_∂pf(x_±, β, η) * p`). Assembled as a linear form on P1 tets, each nodal entry then receives the full cell integral instead of its 1/4 share: **the gradient is exactly 4× too large wherever the filtered field is flat** (direction preserved — measured cos ≈ 0.9999998, ratio 4.000003).

## Why it mattered more than it looked

At uniform initialization `∇ρ̃ ≡ 0` on every design cell, so the whole gradient is scaled 4×. CCSA/CCSAQ then measures an actual-to-predicted decrease ratio of exactly **1/4** on every trial step (measured: 0.250000 across four decades of step length) — below its 1/2 acceptance threshold — so **no step can ever be accepted at any ρ**: the inner loop ratchets ρ up ×1.1 per eval forever and the run freezes bit-exact at the initial design while burning evaluations (observed: 164+ evals with `min(x)=max(x)=0.5` exactly). The branch goes dormant once a design develops (`‖∇ρ̃‖` rises above the cutoff), which is why only fresh-start runs were affected and the bug survived unnoticed.

Causal proof: forcing the legacy projection path (which never enters this branch) flips `‖df/dx‖` by exactly 4 and restores ratio 1.0 — one flag, every link of the chain.

## The fix

One line: the flat-field branch now returns `∂projection_∂pf(ρ̃, β, η) * p`, matching the limit of the non-degenerate branch.

Validated 2026-07-20 in a three-arm head-to-head (OLD Emitter3DTopOpt vs new `:legacy` vs fixed `:current`) on LLSC: the fixed native chain reproduces and then outperforms. Post-fix gate on the exact previously-frozen configuration confirms first-eval `grad_norm` drops to one quarter of the banked pre-fix value and the run escapes uniform on production defaults.

## Tests

`test/projection_derivative_tests.jl`:
- flat-field branch equals `∂projection_∂pf * p` (the factor itself)
- linearity in `p` (the bug made the branch constant in `p`)
- continuity of `DSP_dpf` across the `1e-8` degeneracy threshold (the bug is a 1/p jump there)

Root-caused by Ebenezer (2026-07-20), frozen-run forensics and CCSA escape-race mechanism by Ebenezer & Bombolo (2026-08-07), assembled by Tim — quest engaging-deo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMaB7be9iNaju8j1iE9dbw